### PR TITLE
VLAN dashed list bug

### DIFF
--- a/pynetworking/features/ats_vlan_config_lexer.py
+++ b/pynetworking/features/ats_vlan_config_lexer.py
@@ -73,20 +73,12 @@ class VlanConfigLexer(object):
                     result[vid] = {'name': vid}
                 continue
             if tok.type == 'VLANRANGE':
-                for vid in tok.value.split(','):
-                    print ("vid is \n")
-                    print vid
-                    if '-' in vid:
-                        a = int(vid.split('-')[0])
-                        b = int(vid.split('-')[1]) + 1
-                        print(a)
-                        print("\nboundaries\n")
-                        print(b)
-                        for c in range(a, b):
-                            d = "{0}".format(c)
-                            result[d] = {'name': d}
-                    else:
-                        result[vid] = {'name': vid}
+                vid = tok.value
+                a = int(vid.split('-')[0])
+                b = int(vid.split('-')[1]) + 1
+                for c in range(a, b):
+                    d = "{0}".format(c)
+                    result[d] = {'name': d}
                 continue
             if tok.type == 'name':
                 result[tok.value[0]]['name'] = tok.value[1]

--- a/pynetworking/features/ats_vlan_config_lexer.py
+++ b/pynetworking/features/ats_vlan_config_lexer.py
@@ -10,7 +10,6 @@ class VlanConfigLexer(object):
 
     tokens = (
         'VLANLIST',
-        'VLANRANGE',
         'name',
     )
 
@@ -23,12 +22,7 @@ class VlanConfigLexer(object):
         t.lexer.begin('INITIAL')
 
     def t_vlandb_VLANLIST(self, t):
-        r'vlan\s+\d+(\,\d+)+'
-        t.value = re.split('\s+',t.value)[1]
-        return t
-
-    def t_vlandb_VLANRANGE(self, t):
-        r'vlan\s+\d+\-\d+'
+        r'vlan\s+[^\n]+'
         t.value = re.split('\s+',t.value)[1]
         return t
 
@@ -70,15 +64,15 @@ class VlanConfigLexer(object):
         for tok in self.lexer:
             if tok.type == 'VLANLIST':
                 for vid in tok.value.split(','):
-                    result[vid] = {'name': vid}
-                continue
-            if tok.type == 'VLANRANGE':
-                vid = tok.value
-                a = int(vid.split('-')[0])
-                b = int(vid.split('-')[1]) + 1
-                for c in range(a, b):
-                    d = "{0}".format(c)
-                    result[d] = {'name': d}
+                    if '-' in vid:
+                        a = int(vid.split('-')[0])
+                        b = int(vid.split('-')[1]) + 1
+                        for c in range(a, b):
+                            d = "{0}".format(c)
+                            result[d] = {'name': d}
+                        continue
+                    else:
+                        result[vid] = {'name': vid}
                 continue
             if tok.type == 'name':
                 result[tok.value[0]]['name'] = tok.value[1]

--- a/pynetworking/features/ats_vlan_config_lexer.py
+++ b/pynetworking/features/ats_vlan_config_lexer.py
@@ -26,35 +26,35 @@ class VlanConfigLexer(object):
     def t_vlandb_VLANLIST(self, t):
         r'vlan\s+[^\n]+'
         # r'vlan\s+\d+(\,\d+)+'
-        print ("BEFORE SPLIT\n")
-        print (t.value)
+        # print ("BEFORE SPLIT\n")
+        # print (t.value)
         t.value = re.split('\s+',t.value)[1]
-        print ("AFTER SPLIT\n")
-        print (t.value)
-        print ("DONE\n")
+        # print ("AFTER SPLIT\n")
+        # print (t.value)
+        # print ("DONE\n")
         return t
 
-    def t_vlandb_VLANRANGE(self, t):
-        r'vlan\s+\d+\-\d+'
-        print ("BEFORE SPLIT\n")
-        print (t.value)
-        t.value = re.split('\s+',t.value)[1]
-        print ("AFTER SPLITTED\n")
-        print (t.value)
-        print ("DONE\n")
-        # t.lexer.push_state('vlanrange')
-        # # str = t.value
-        # # a = str.split('-')[0]
-        # # b = str.split('-')[1]
-        # print ("RESPLIT\n")
-        # print (a)
-        # print ("\n")
-        # print (b)
-        # print ("RESPLIT\n")
-        # t.value = a + ',' + b
-        # t.lexer.push_state('vlanrange')
-        # t.lexer.id = t.value
-        return t
+    # def t_vlandb_VLANRANGE(self, t):
+    #     r'vlan\s+\d+\-\d+'
+    #     print ("BEFORE SPLIT\n")
+    #     print (t.value)
+    #     t.value = re.split('\s+',t.value)[1]
+    #     print ("AFTER SPLITTED\n")
+    #     print (t.value)
+    #     print ("DONE\n")
+    #     # t.lexer.push_state('vlanrange')
+    #     # # str = t.value
+    #     # # a = str.split('-')[0]
+    #     # # b = str.split('-')[1]
+    #     # print ("RESPLIT\n")
+    #     # print (a)
+    #     # print ("\n")
+    #     # print (b)
+    #     # print ("RESPLIT\n")
+    #     # t.value = a + ',' + b
+    #     # t.lexer.push_state('vlanrange')
+    #     # t.lexer.id = t.value
+    #     return t
 
     # def t_vlanid_vlanrange_newline(self, t):
     #    r'\n+'
@@ -108,10 +108,18 @@ class VlanConfigLexer(object):
                     print ("vid is \n")
                     print vid
                     if '-' in vid:
-                        a = vid.split('-')[0]
-                        b = vid.split('-')[1]
-                        result[a] = {'name': a}
-                        result[b] = {'name': b}
+                        # a = vid.split('-')[0]
+                        # b = vid.split('-')[1]
+                        # result[a] = {'name': a}
+                        # result[b] = {'name': b}
+                        a = int(vid.split('-')[0])
+                        b = int(vid.split('-')[1]) + 1
+                        print(a)
+                        print("\nboundaries\n")
+                        print(b)
+                        for c in range(a, b):
+                            d = "{0}".format(c)
+                            result[d] = {'name': d}
                     else:
                         result[vid] = {'name': vid}
                 continue

--- a/pynetworking/features/ats_vlan_config_lexer.py
+++ b/pynetworking/features/ats_vlan_config_lexer.py
@@ -6,10 +6,12 @@ class VlanConfigLexer(object):
     states = (
         ('vlandb','exclusive'),
         ('vlaninterface','exclusive'),
-    )
+        # ('vlanrange','exclusive'),
+)
 
     tokens = (
         'VLANLIST',
+        'VLANRANGE',
         'name',
     )
 
@@ -23,9 +25,42 @@ class VlanConfigLexer(object):
 
     def t_vlandb_VLANLIST(self, t):
         r'vlan\s+[^\n]+'
+        # r'vlan\s+\d+(\,\d+)+'
+        print ("BEFORE SPLIT\n")
+        print (t.value)
         t.value = re.split('\s+',t.value)[1]
+        print ("AFTER SPLIT\n")
+        print (t.value)
+        print ("DONE\n")
         return t
 
+    def t_vlandb_VLANRANGE(self, t):
+        r'vlan\s+\d+\-\d+'
+        print ("BEFORE SPLIT\n")
+        print (t.value)
+        t.value = re.split('\s+',t.value)[1]
+        print ("AFTER SPLITTED\n")
+        print (t.value)
+        print ("DONE\n")
+        # t.lexer.push_state('vlanrange')
+        # # str = t.value
+        # # a = str.split('-')[0]
+        # # b = str.split('-')[1]
+        # print ("RESPLIT\n")
+        # print (a)
+        # print ("\n")
+        # print (b)
+        # print ("RESPLIT\n")
+        # t.value = a + ',' + b
+        # t.lexer.push_state('vlanrange')
+        # t.lexer.id = t.value
+        return t
+
+    # def t_vlanid_vlanrange_newline(self, t):
+    #    r'\n+'
+    #    t.lexer.lineno += len(t.value)
+    #    t.lexer.pop_state()
+    #
     def t_INITIAL_VLANINTERFACE_START(self, t):
         r'interface\s+vlan\s+\d+'
         t.lexer.begin('vlaninterface')
@@ -62,12 +97,27 @@ class VlanConfigLexer(object):
         self.lexer.input(data)
         result = {'1': {'name':'1'}}
         for tok in self.lexer:
+            print("tok is")
+            print(tok)
+            # if tok.type == 'VLANLIST':
+            #     for vid in tok.value.split(','):
+            #         result[vid] = {'name': vid}
+            #     continue
             if tok.type == 'VLANLIST':
                 for vid in tok.value.split(','):
-                    result[vid] = {'name': vid}
+                    print ("vid is \n")
+                    print vid
+                    if '-' in vid:
+                        a = vid.split('-')[0]
+                        b = vid.split('-')[1]
+                        result[a] = {'name': a}
+                        result[b] = {'name': b}
+                    else:
+                        result[vid] = {'name': vid}
                 continue
+            if tok.type == 'VLANRANGE':
+                print('TO BE WRITTEN')
             if tok.type == 'name':
                 result[tok.value[0]]['name'] = tok.value[1]
 
         return result
-

--- a/pynetworking/features/ats_vlan_config_lexer.py
+++ b/pynetworking/features/ats_vlan_config_lexer.py
@@ -6,8 +6,7 @@ class VlanConfigLexer(object):
     states = (
         ('vlandb','exclusive'),
         ('vlaninterface','exclusive'),
-        # ('vlanrange','exclusive'),
-)
+    )
 
     tokens = (
         'VLANLIST',
@@ -24,43 +23,15 @@ class VlanConfigLexer(object):
         t.lexer.begin('INITIAL')
 
     def t_vlandb_VLANLIST(self, t):
-        r'vlan\s+[^\n]+'
-        # r'vlan\s+\d+(\,\d+)+'
-        # print ("BEFORE SPLIT\n")
-        # print (t.value)
+        r'vlan\s+\d+(\,\d+)+'
         t.value = re.split('\s+',t.value)[1]
-        # print ("AFTER SPLIT\n")
-        # print (t.value)
-        # print ("DONE\n")
         return t
 
-    # def t_vlandb_VLANRANGE(self, t):
-    #     r'vlan\s+\d+\-\d+'
-    #     print ("BEFORE SPLIT\n")
-    #     print (t.value)
-    #     t.value = re.split('\s+',t.value)[1]
-    #     print ("AFTER SPLITTED\n")
-    #     print (t.value)
-    #     print ("DONE\n")
-    #     # t.lexer.push_state('vlanrange')
-    #     # # str = t.value
-    #     # # a = str.split('-')[0]
-    #     # # b = str.split('-')[1]
-    #     # print ("RESPLIT\n")
-    #     # print (a)
-    #     # print ("\n")
-    #     # print (b)
-    #     # print ("RESPLIT\n")
-    #     # t.value = a + ',' + b
-    #     # t.lexer.push_state('vlanrange')
-    #     # t.lexer.id = t.value
-    #     return t
+    def t_vlandb_VLANRANGE(self, t):
+        r'vlan\s+\d+\-\d+'
+        t.value = re.split('\s+',t.value)[1]
+        return t
 
-    # def t_vlanid_vlanrange_newline(self, t):
-    #    r'\n+'
-    #    t.lexer.lineno += len(t.value)
-    #    t.lexer.pop_state()
-    #
     def t_INITIAL_VLANINTERFACE_START(self, t):
         r'interface\s+vlan\s+\d+'
         t.lexer.begin('vlaninterface')
@@ -97,21 +68,15 @@ class VlanConfigLexer(object):
         self.lexer.input(data)
         result = {'1': {'name':'1'}}
         for tok in self.lexer:
-            print("tok is")
-            print(tok)
-            # if tok.type == 'VLANLIST':
-            #     for vid in tok.value.split(','):
-            #         result[vid] = {'name': vid}
-            #     continue
             if tok.type == 'VLANLIST':
+                for vid in tok.value.split(','):
+                    result[vid] = {'name': vid}
+                continue
+            if tok.type == 'VLANRANGE':
                 for vid in tok.value.split(','):
                     print ("vid is \n")
                     print vid
                     if '-' in vid:
-                        # a = vid.split('-')[0]
-                        # b = vid.split('-')[1]
-                        # result[a] = {'name': a}
-                        # result[b] = {'name': b}
                         a = int(vid.split('-')[0])
                         b = int(vid.split('-')[1]) + 1
                         print(a)
@@ -123,8 +88,6 @@ class VlanConfigLexer(object):
                     else:
                         result[vid] = {'name': vid}
                 continue
-            if tok.type == 'VLANRANGE':
-                print('TO BE WRITTEN')
             if tok.type == 'name':
                 result[tok.value[0]]['name'] = tok.value[1]
 

--- a/pynetworking/features/awp_license.py
+++ b/pynetworking/features/awp_license.py
@@ -149,6 +149,7 @@ class awp_license(Feature):
             if m:
                 key = m.group('name')
                 fflist = line.split(': ')[-1]
+                fflist = fflist.split('\r\n\r\n')[0]
                 fflist = fflist.replace(' ', '')
                 fflist = fflist.replace('\n', '')
                 fflist = fflist.replace('\r', '')

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -14,6 +14,146 @@ Build type : RELEASE
     """]})
 
 
+def test_two_vlans(dut, log_level):
+    output_show_rcfg = ["""
+!
+interface port1.0.1-1.0.50
+ switchport
+ switchport mode access
+!
+vlan database
+vlan 10,21-22
+exit
+interface vlan 21
+name "twentyone"
+exit
+interface vlan 22
+name "zweiundzwanzig"
+exit
+interface vlan 1
+ip address 10.17.39.253 255.255.255.0
+name default
+exit
+!
+end
+    """]
+    output_show_vlan = ["""
+VLAN ID  Name            Type    State   Member ports
+                                         (u)-Untagged, (t)-Tagged
+======= ================ ======= ======= ====================================
+1       default          STATIC  ACTIVE  port1.0.1(u) port1.0.2(u) port1.0.3(u)
+                                         port1.0.4(u) port1.0.5(u) port1.0.6(u)
+                                         port1.0.7(u) port1.0.8(u) port1.0.9(u)
+                                         port1.0.10(u) port1.0.11(u)
+                                         port1.0.12(t) port1.0.13(u)
+                                         port1.0.14(u) port1.0.15(u)
+                                         port1.0.16(u) port1.0.17(u)
+                                         port1.0.18(u) port1.0.19(u)
+                                         port1.0.20(t) port1.0.21(u)
+                                         port1.0.22(u) port1.0.23(u)
+                                         port1.0.24(u) port1.0.25(u)
+                                         port1.0.26(u) port1.0.27(u)
+                                         port1.0.28(u) port1.0.29(u)
+                                         port1.0.31(u)
+                                         port1.0.32(u) port1.0.33(u)
+                                         port1.0.34(u) port1.0.35(u)
+                                         port1.0.36(u) port1.0.37(u)
+                                         port1.0.38(u) port1.0.39(u)
+                                         port1.0.40(u) port1.0.41(u)
+                                         port1.0.44(u) port1.0.45(u)
+                                         port1.0.46(u) port1.0.47(u)
+                                         port1.0.48(u) port1.0.49(u)
+                                         port1.0.50(u)
+21      twentyone        STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+22      zweiundzwanzig   STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+    """]
+
+    setup_dut(dut)
+    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_show_rcfg})
+    dut.add_cmd({'cmd': 'show vlan all'      , 'state':0 , 'action':'PRINT'     ,'args': output_show_vlan})
+    d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
+    d.open()
+    assert '21' in d.vlan
+    assert d.vlan[21]['name'] == 'twentyone'
+    assert ('22', {'current state': 'ACTIVE', 'name': 'zweiundzwanzig', 'untagged': (), 'tagged': ('1.0.42', '1.0.43'), 'type': 'STATIC'}) in d.vlan.items()
+    with pytest.raises(TypeError) as excinfo:
+        d.vlan[d.vlan]
+    str(d.vlan)
+    d.close()
+
+
+def test_three_vlans(dut, log_level):
+    output_show_rcfg = ["""
+!
+interface port1.0.1-1.0.50
+ switchport
+ switchport mode access
+!
+vlan database
+vlan 21-22,30
+exit
+interface vlan 21
+name "twentyone"
+exit
+interface vlan 22
+name "zweiundzwanzig"
+exit
+interface vlan 30
+name "trenta"
+exit
+interface vlan 1
+ip address 10.17.39.253 255.255.255.0
+name default
+exit
+!
+end
+    """]
+    output_show_vlan = ["""
+VLAN ID  Name            Type    State   Member ports
+                                         (u)-Untagged, (t)-Tagged
+======= ================ ======= ======= ====================================
+1       default          STATIC  ACTIVE  port1.0.1(u) port1.0.2(u) port1.0.3(u)
+                                         port1.0.4(u) port1.0.5(u) port1.0.6(u)
+                                         port1.0.7(u) port1.0.8(u) port1.0.9(u)
+                                         port1.0.10(u) port1.0.11(u)
+                                         port1.0.12(t) port1.0.13(u)
+                                         port1.0.14(u) port1.0.15(u)
+                                         port1.0.16(u) port1.0.17(u)
+                                         port1.0.18(u) port1.0.19(u)
+                                         port1.0.20(t) port1.0.21(u)
+                                         port1.0.22(u) port1.0.23(u)
+                                         port1.0.24(u) port1.0.25(u)
+                                         port1.0.26(u) port1.0.27(u)
+                                         port1.0.28(u) port1.0.29(u)
+                                         port1.0.31(u)
+                                         port1.0.32(u) port1.0.33(u)
+                                         port1.0.34(u) port1.0.35(u)
+                                         port1.0.36(u) port1.0.37(u)
+                                         port1.0.38(u) port1.0.39(u)
+                                         port1.0.40(u) port1.0.41(u)
+                                         port1.0.44(u) port1.0.45(u)
+                                         port1.0.46(u) port1.0.47(u)
+                                         port1.0.48(u) port1.0.49(u)
+                                         port1.0.50(u)
+21      twentyone        STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+22      zweiundzwanzig   STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+30      trenta           STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+    """]
+
+    setup_dut(dut)
+    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_show_rcfg})
+    dut.add_cmd({'cmd': 'show vlan all'      , 'state':0 , 'action':'PRINT'     ,'args': output_show_vlan})
+    d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
+    d.open()
+    assert '21' in d.vlan
+    assert d.vlan[21]['name'] == 'twentyone'
+    assert '22' in d.vlan
+    assert d.vlan[22]['name'] == 'zweiundzwanzig'
+    assert '30' in d.vlan
+    assert d.vlan[30]['name'] == 'trenta'
+    d.close()
+
+
 def test_get_vlan(dut, log_level):
     setup_dut(dut)
     dut.add_cmd({'cmd':'show running-config', 'state':0, 'action': 'PRINT','args':["""

--- a/tests/test_vlan.py
+++ b/tests/test_vlan.py
@@ -14,146 +14,6 @@ Build type : RELEASE
     """]})
 
 
-def test_two_vlans(dut, log_level):
-    output_show_rcfg = ["""
-!
-interface port1.0.1-1.0.50
- switchport
- switchport mode access
-!
-vlan database
-vlan 10,21-22
-exit
-interface vlan 21
-name "twentyone"
-exit
-interface vlan 22
-name "zweiundzwanzig"
-exit
-interface vlan 1
-ip address 10.17.39.253 255.255.255.0
-name default
-exit
-!
-end
-    """]
-    output_show_vlan = ["""
-VLAN ID  Name            Type    State   Member ports
-                                         (u)-Untagged, (t)-Tagged
-======= ================ ======= ======= ====================================
-1       default          STATIC  ACTIVE  port1.0.1(u) port1.0.2(u) port1.0.3(u)
-                                         port1.0.4(u) port1.0.5(u) port1.0.6(u)
-                                         port1.0.7(u) port1.0.8(u) port1.0.9(u)
-                                         port1.0.10(u) port1.0.11(u)
-                                         port1.0.12(t) port1.0.13(u)
-                                         port1.0.14(u) port1.0.15(u)
-                                         port1.0.16(u) port1.0.17(u)
-                                         port1.0.18(u) port1.0.19(u)
-                                         port1.0.20(t) port1.0.21(u)
-                                         port1.0.22(u) port1.0.23(u)
-                                         port1.0.24(u) port1.0.25(u)
-                                         port1.0.26(u) port1.0.27(u)
-                                         port1.0.28(u) port1.0.29(u)
-                                         port1.0.31(u)
-                                         port1.0.32(u) port1.0.33(u)
-                                         port1.0.34(u) port1.0.35(u)
-                                         port1.0.36(u) port1.0.37(u)
-                                         port1.0.38(u) port1.0.39(u)
-                                         port1.0.40(u) port1.0.41(u)
-                                         port1.0.44(u) port1.0.45(u)
-                                         port1.0.46(u) port1.0.47(u)
-                                         port1.0.48(u) port1.0.49(u)
-                                         port1.0.50(u)
-21      twentyone        STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
-22      zweiundzwanzig   STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
-    """]
-
-    setup_dut(dut)
-    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_show_rcfg})
-    dut.add_cmd({'cmd': 'show vlan all'      , 'state':0 , 'action':'PRINT'     ,'args': output_show_vlan})
-    d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
-    d.open()
-    assert '21' in d.vlan
-    assert d.vlan[21]['name'] == 'twentyone'
-    assert ('22', {'current state': 'ACTIVE', 'name': 'zweiundzwanzig', 'untagged': (), 'tagged': ('1.0.42', '1.0.43'), 'type': 'STATIC'}) in d.vlan.items()
-    with pytest.raises(TypeError) as excinfo:
-        d.vlan[d.vlan]
-    str(d.vlan)
-    d.close()
-
-
-def test_three_vlans(dut, log_level):
-    output_show_rcfg = ["""
-!
-interface port1.0.1-1.0.50
- switchport
- switchport mode access
-!
-vlan database
-vlan 21-22,30
-exit
-interface vlan 21
-name "twentyone"
-exit
-interface vlan 22
-name "zweiundzwanzig"
-exit
-interface vlan 30
-name "trenta"
-exit
-interface vlan 1
-ip address 10.17.39.253 255.255.255.0
-name default
-exit
-!
-end
-    """]
-    output_show_vlan = ["""
-VLAN ID  Name            Type    State   Member ports
-                                         (u)-Untagged, (t)-Tagged
-======= ================ ======= ======= ====================================
-1       default          STATIC  ACTIVE  port1.0.1(u) port1.0.2(u) port1.0.3(u)
-                                         port1.0.4(u) port1.0.5(u) port1.0.6(u)
-                                         port1.0.7(u) port1.0.8(u) port1.0.9(u)
-                                         port1.0.10(u) port1.0.11(u)
-                                         port1.0.12(t) port1.0.13(u)
-                                         port1.0.14(u) port1.0.15(u)
-                                         port1.0.16(u) port1.0.17(u)
-                                         port1.0.18(u) port1.0.19(u)
-                                         port1.0.20(t) port1.0.21(u)
-                                         port1.0.22(u) port1.0.23(u)
-                                         port1.0.24(u) port1.0.25(u)
-                                         port1.0.26(u) port1.0.27(u)
-                                         port1.0.28(u) port1.0.29(u)
-                                         port1.0.31(u)
-                                         port1.0.32(u) port1.0.33(u)
-                                         port1.0.34(u) port1.0.35(u)
-                                         port1.0.36(u) port1.0.37(u)
-                                         port1.0.38(u) port1.0.39(u)
-                                         port1.0.40(u) port1.0.41(u)
-                                         port1.0.44(u) port1.0.45(u)
-                                         port1.0.46(u) port1.0.47(u)
-                                         port1.0.48(u) port1.0.49(u)
-                                         port1.0.50(u)
-21      twentyone        STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
-22      zweiundzwanzig   STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
-30      trenta           STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
-    """]
-
-    setup_dut(dut)
-    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_show_rcfg})
-    dut.add_cmd({'cmd': 'show vlan all'      , 'state':0 , 'action':'PRINT'     ,'args': output_show_vlan})
-    d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
-    d.open()
-    assert '21' in d.vlan
-    assert d.vlan[21]['name'] == 'twentyone'
-    assert '22' in d.vlan
-    assert d.vlan[22]['name'] == 'zweiundzwanzig'
-    assert '30' in d.vlan
-    assert d.vlan[30]['name'] == 'trenta'
-    d.close()
-
-
 def test_get_vlan(dut, log_level):
     setup_dut(dut)
     dut.add_cmd({'cmd':'show running-config', 'state':0, 'action': 'PRINT','args':["""
@@ -229,6 +89,104 @@ VLAN ID  Name            Type    State   Member ports
     with pytest.raises(KeyError) as excinfo:
         d.vlan[1111]
     assert 'vlan id 1111 does not exist' in excinfo.value
+    d.close()
+
+
+def test_vlan_dashed_list(dut, log_level):
+    output_show_rcfg = ["""
+!
+interface port1.0.1-1.0.50
+ switchport
+ switchport mode access
+!
+vlan database
+vlan 21-23,25,30-33
+exit
+interface vlan 21
+name "twentyone"
+exit
+interface vlan 22
+name "zweiundzwanzig"
+exit
+interface vlan 23
+name "vingttrois"
+exit
+interface vlan 25
+name "venticinque"
+exit
+interface vlan 32
+name "telnet vlan"
+exit
+interface vlan 1
+ip address 10.17.39.253 255.255.255.0
+name default
+exit
+!
+end
+    """]
+    output_show_vlan = ["""
+VLAN ID  Name            Type    State   Member ports
+                                         (u)-Untagged, (t)-Tagged
+======= ================ ======= ======= ====================================
+1       default          STATIC  ACTIVE  port1.0.1(u) port1.0.2(u) port1.0.3(u)
+                                         port1.0.4(u) port1.0.5(u) port1.0.6(u)
+                                         port1.0.7(u) port1.0.8(u) port1.0.9(u)
+                                         port1.0.10(u) port1.0.11(u)
+                                         port1.0.12(t) port1.0.13(u)
+                                         port1.0.14(u) port1.0.15(u)
+                                         port1.0.16(u) port1.0.17(u)
+                                         port1.0.18(u) port1.0.19(u)
+                                         port1.0.20(t) port1.0.21(u)
+                                         port1.0.22(u) port1.0.23(u)
+                                         port1.0.24(u) port1.0.25(u)
+                                         port1.0.26(u) port1.0.27(u)
+                                         port1.0.28(u) port1.0.29(u)
+                                         port1.0.30(u) port1.0.31(u)
+                                         port1.0.32(u) port1.0.33(u)
+                                         port1.0.34(u) port1.0.35(u)
+                                         port1.0.36(u) port1.0.37(u)
+                                         port1.0.38(u) port1.0.39(u)
+                                         port1.0.40(u) port1.0.41(u)
+                                         port1.0.44(u) port1.0.45(u)
+                                         port1.0.46(u) port1.0.47(u)
+                                         port1.0.48(u) port1.0.49(u)
+                                         port1.0.50(u)
+21      twentyone        STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+22      zweiundzwanzig   STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+23      vingttrois       STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+25      venticinque      STATIC  ACTIVE  port1.0.42(t) port1.0.43(t)
+30      VLAN0030         STATIC  SUSPEND
+31      VLAN0031         STATIC  SUSPEND
+32      "telnet vlan"    STATIC  SUSPEND
+33      VLAN0033         STATIC  SUSPEND
+    """]
+
+    setup_dut(dut)
+    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_show_rcfg})
+    dut.add_cmd({'cmd': 'show vlan all'      , 'state':0 , 'action':'PRINT'     ,'args': output_show_vlan})
+    d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
+    d.open()
+    assert '21' in d.vlan
+    assert d.vlan[21]['name'] == 'twentyone'
+    assert ('22', {'current state': 'ACTIVE', 'name': 'zweiundzwanzig', 'untagged': (), 'tagged': ('1.0.42', '1.0.43'), 'type': 'STATIC'}) in d.vlan.items()
+    with pytest.raises(TypeError) as excinfo:
+        d.vlan[d.vlan]
+    str(d.vlan)
+    assert '23' in d.vlan
+    assert d.vlan[23]['name'] == 'vingttrois'
+    assert '24' not in d.vlan
+    assert '25' in d.vlan
+    assert d.vlan[25]['name'] == 'venticinque'
+    assert '26' not in d.vlan
+    assert '27' not in d.vlan
+    assert '28' not in d.vlan
+    assert '29' not in d.vlan
+    assert '30' in d.vlan
+    assert d.vlan[30]['name'] == 'VLAN0030'
+    assert '31' in d.vlan
+    assert '32' in d.vlan
+    assert d.vlan[32]['name'] == 'telnet vlan'
+    assert '33' in d.vlan
     d.close()
 
 

--- a/tests/test_vlan_ats.py
+++ b/tests/test_vlan_ats.py
@@ -31,6 +31,207 @@ Serial number:
     """]})
 
 
+def test_dashed_vlan(dut, log_level):
+    output_sv_0 = ["""
+
+Vlan       Name                   Ports                Type     Authorization
+---- ----------------- --------------------------- ------------ -------------
+ 1           1         1/e(1-48),1/g(1-4),          other       Required
+                       2/e(1-48),2/g(1-4),
+                       3/e(1-48),3/g(1-4),
+                       4/e(1-48),4/g(1-4),
+                       5/e(1-48),5/g(1-4),
+                       6/e(1-48),6/g(1-4),ch(1-8)
+    """]
+    output_sr_0 = ["""
+interface vlan 1
+ip address 10.17.39.252 255.255.255.0
+name default_vlan
+exit
+hostname nac_dev
+ip ssh server
+    """]
+
+    output_sv_1 = ["""
+
+Vlan       Name                   Ports                Type     Authorization
+---- ----------------- --------------------------- ------------ -------------
+ 1           1         1/e(1-48),1/g(1-4),          other       Required
+                       2/e(1-48),2/g(1-4),
+                       3/e(1-48),3/g(1-4),
+                       4/e(1-48),4/g(1-4),
+                       5/e(1-48),5/g(1-4),
+                       6/e(1-48),6/g(1-4),ch(1-8)
+ 21          21                                     permanent     Required
+ 22          22                                     permanent     Required
+ 23          23                                     permanent     Required
+ 24          24                                     permanent     Required
+ 25          25                                     permanent     Required
+    """]
+    output_sr_1 = ["""
+vlan database
+vlan 21-25
+exit
+interface vlan 21
+name "twentyone"
+exit
+interface vlan 22
+name "zweiundzwanzig"
+exit
+interface vlan 23
+name "vingttrois"
+exit
+interface vlan 24
+name "ventiquattro"
+exit
+interface vlan 25
+name "vienticinco"
+exit
+interface vlan 1
+ip address 10.17.39.252 255.255.255.0
+name default_vlan
+exit
+hostname nac_dev
+ip ssh server
+    """]
+
+    setup_dut(dut)
+    dut.add_cmd({'cmd': 'show vlan'          , 'state':0 , 'action':'PRINT'     ,'args': output_sv_0})
+    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_sr_0})
+    dut.add_cmd({'cmd': 'vlan database'      , 'state':0 , 'action':'SET_PROMPT','args':['(config-vlan)#']})
+    dut.add_cmd({'cmd': 'vlan database'      , 'state':0 , 'action':'SET_STATE' ,'args':[1]})
+    dut.add_cmd({'cmd': 'vlan 21-25'         , 'state':1 , 'action':'SET_STATE' ,'args':[2]})
+    dut.add_cmd({'cmd': 'show vlan'          , 'state':2 , 'action':'PRINT'     ,'args':output_sv_1})
+    dut.add_cmd({'cmd': 'show running-config', 'state':2 , 'action':'PRINT'     ,'args':output_sr_1})
+    dut.add_cmd({'cmd': 'interface vlan 21'  , 'state':2 , 'action':'SET_PROMPT','args':['(config-if)#']})
+    dut.add_cmd({'cmd': 'interface vlan 21'  , 'state':2 , 'action':'SET_STATE' ,'args':[3]})
+    dut.add_cmd({'cmd': 'name twentyone'     , 'state':3 , 'action':'SET_STATE' ,'args':[4]})
+    # dut.add_cmd({'cmd': 'show vlan'          , 'state':4 , 'action':'PRINT'     ,'args':output_sv_1})
+    # dut.add_cmd({'cmd': 'show running-config', 'state':4 , 'action':'PRINT'     ,'args':output_sr_1})
+    dut.add_cmd({'cmd': 'interface vlan 22'  , 'state':4 , 'action':'SET_PROMPT','args':['(config-if)#']})
+    dut.add_cmd({'cmd': 'interface vlan 22'  , 'state':4 , 'action':'SET_STATE' ,'args':[5]})
+    dut.add_cmd({'cmd': 'name zweiundzwanzig', 'state':5 , 'action':'SET_STATE' ,'args':[6]})
+    # dut.add_cmd({'cmd': 'show vlan'          , 'state':6 , 'action':'PRINT'     ,'args':output_sv_1})
+    # dut.add_cmd({'cmd': 'show running-config', 'state':6 , 'action':'PRINT'     ,'args':output_sr_1})
+    dut.add_cmd({'cmd': 'interface vlan 23'  , 'state':6 , 'action':'SET_PROMPT','args':['(config-if)#']})
+    dut.add_cmd({'cmd': 'interface vlan 23'  , 'state':6 , 'action':'SET_STATE' ,'args':[7]})
+    dut.add_cmd({'cmd': 'name vingttrois'    , 'state':7 , 'action':'SET_STATE' ,'args':[8]})
+    # dut.add_cmd({'cmd': 'show vlan'          , 'state':7 , 'action':'PRINT'     ,'args':output_sv_1})
+    # dut.add_cmd({'cmd': 'show running-config', 'state':7 , 'action':'PRINT'     ,'args':output_sr_1})
+    dut.add_cmd({'cmd': 'interface vlan 24'  , 'state':8 , 'action':'SET_PROMPT','args':['(config-if)#']})
+    dut.add_cmd({'cmd': 'interface vlan 24'  , 'state':8 , 'action':'SET_STATE' ,'args':[9]})
+    dut.add_cmd({'cmd': 'name ventiquattro'  , 'state':9 , 'action':'SET_STATE' ,'args':[10]})
+    # dut.add_cmd({'cmd': 'show vlan'          , 'state':10, 'action':'PRINT'     ,'args':output_sv_1})
+    # dut.add_cmd({'cmd': 'show running-config', 'state':10, 'action':'PRINT'     ,'args':output_sr_1})
+    dut.add_cmd({'cmd': 'interface vlan 25'  , 'state':10, 'action':'SET_PROMPT','args':['(config-if)#']})
+    dut.add_cmd({'cmd': 'interface vlan 25'  , 'state':10, 'action':'SET_STATE' ,'args':[11]})
+    dut.add_cmd({'cmd': 'name vienticinco'   , 'state':11, 'action':'SET_STATE' ,'args':[12]})
+    dut.add_cmd({'cmd': 'show vlan'          , 'state':12, 'action':'PRINT'     ,'args':output_sv_1})
+    dut.add_cmd({'cmd': 'show running-config', 'state':12, 'action':'PRINT'     ,'args':output_sr_1})
+    d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
+    d.open()
+    # d.vlan.create(21)
+    # # d.vlan.create(22)
+    # # d.vlan.create(23)
+    # # d.vlan.create(24)
+    # # d.vlan.create(25)
+    d.vlan.create(21, name='twentyone')
+    d.vlan.create(22, name='zweiundzwanzig')
+    d.vlan.create(23, name='vingttrois')
+    d.vlan.create(24, name='ventiquattro')
+    d.vlan.create(25, name='vienticinco')
+    # d.vlan.update(21, name='twentyone')
+    # d.vlan.update(22, name='zweiundzwanzig')
+    # d.vlan.update(23, name='vingttrois')
+    # d.vlan.update(24, name='ventiquattro')
+    # d.vlan.update(25, name='vienticinco')
+    assert '21' in d.vlan
+    assert '22' in d.vlan
+    assert '23' in d.vlan
+    assert '24' in d.vlan
+    assert '25' in d.vlan
+    d.close()
+
+
+def test_two_vlans(dut, log_level):
+    output_sv_0 = ["""
+
+Vlan       Name                   Ports                Type     Authorization
+---- ----------------- --------------------------- ------------ -------------
+ 1           1         1/e(1-48),1/g(1-4),          other       Required
+                       2/e(1-48),2/g(1-4),
+                       3/e(1-48),3/g(1-4),
+                       4/e(1-48),4/g(1-4),
+                       5/e(1-48),5/g(1-4),
+                       6/e(1-48),6/g(1-4),ch(1-8)
+    """]
+    output_sr_0 = ["""
+interface vlan 1
+ip address 10.17.39.252 255.255.255.0
+name default_vlan
+exit
+hostname nac_dev
+ip ssh server
+    """]
+
+    output_sv_1 = ["""
+
+Vlan       Name                   Ports                Type     Authorization
+---- ----------------- --------------------------- ------------ -------------
+ 1           1         1/e(1-48),1/g(1-4),          other       Required
+                       2/e(1-48),2/g(1-4),
+                       3/e(1-48),3/g(1-4),
+                       4/e(1-48),4/g(1-4),
+                       5/e(1-48),5/g(1-4),
+                       6/e(1-48),6/g(1-4),ch(1-8)
+ 21          21                                     permanent     Required
+ 22          22                                     permanent     Required
+    """]
+    output_sr_1 = ["""
+vlan database
+vlan 21,22
+exit
+interface vlan 21
+name "twentyone"
+exit
+interface vlan 1
+ip address 10.17.39.252 255.255.255.0
+name default_vlan
+exit
+hostname nac_dev
+ip ssh server
+    """]
+
+    setup_dut(dut)
+    dut.add_cmd({'cmd': 'show vlan'          , 'state':0 , 'action':'PRINT'     ,'args': output_sv_0})
+    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_sr_0})
+    dut.add_cmd({'cmd': 'vlan database'      , 'state':0 , 'action':'SET_PROMPT','args':['(config-vlan)#']})
+    dut.add_cmd({'cmd': 'vlan database'      , 'state':0 , 'action':'SET_STATE' ,'args':[1]})
+    dut.add_cmd({'cmd': 'vlan 21'         , 'state':1 , 'action':'SET_STATE' ,'args':[2]})
+    dut.add_cmd({'cmd': 'show vlan'          , 'state':2 , 'action':'PRINT'     ,'args':output_sv_1})
+    dut.add_cmd({'cmd': 'show running-config', 'state':2 , 'action':'PRINT'     ,'args':output_sr_1})
+    dut.add_cmd({'cmd': 'interface vlan 21'  , 'state':2 , 'action':'SET_PROMPT','args':['(config-if)#']})
+    dut.add_cmd({'cmd': 'interface vlan 21'  , 'state':2 , 'action':'SET_STATE' ,'args':[3]})
+    dut.add_cmd({'cmd': 'name twentyone'     , 'state':3 , 'action':'SET_STATE' ,'args':[4]})
+    dut.add_cmd({'cmd': 'show vlan'          , 'state':4 , 'action':'PRINT'     ,'args':output_sv_1})
+    dut.add_cmd({'cmd': 'show running-config', 'state':4 , 'action':'PRINT'     ,'args':output_sr_1})
+    # dut.add_cmd({'cmd': 'interface vlan 22'  , 'state':4 , 'action':'SET_PROMPT','args':['(config-if)#']})
+    # dut.add_cmd({'cmd': 'interface vlan 22'  , 'state':4 , 'action':'SET_STATE' ,'args':[5]})
+    # dut.add_cmd({'cmd': 'name zweiundzwanzig', 'state':5 , 'action':'SET_STATE' ,'args':[6]})
+    # dut.add_cmd({'cmd': 'show vlan'          , 'state':6 , 'action':'PRINT'     ,'args':output_sv_1})
+    # dut.add_cmd({'cmd': 'show running-config', 'state':6 , 'action':'PRINT'     ,'args':output_sr_1})
+    d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
+    d.open()
+    d.vlan.create(21, name='twentyone')
+    # d.vlan.create(22)
+    # d.vlan.create(22, name='zweiundzwanzig')
+    # d.vlan.update(21, name='twentyone')
+    # d.vlan.update(22, name='zweiundzwanzig')
+    assert '21' in d.vlan
+    # assert '22' in d.vlan
+    d.close()
+
+
 def test_get_vlan(dut, log_level):
     setup_dut(dut)
     dut.add_cmd({'cmd':'show interfaces status', 'state':0, 'action':'PRINT','args':["""

--- a/tests/test_vlan_ats.py
+++ b/tests/test_vlan_ats.py
@@ -323,10 +323,10 @@ Vlan       Name                   Ports                Type     Authorization
     dut.add_cmd({'cmd': 'show vlan'          , 'state':0 , 'action':'PRINT'     ,'args': output_show_vlan})
     d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
     d.open()
-    assert '21' in d.vlan
+    with pytest.raises(TypeError) as excinfo:
+        d.vlan[d.vlan]
     assert d.vlan[21]['name'] == 'twentyone'
-    assert '22' in d.vlan
-    assert d.vlan[22]['name'] == 'zweiundzwanzig'
+    assert ('22', {'name': 'zweiundzwanzig', 'tagged': [], 'type': 'permanent', 'untagged': []}) in d.vlan.items()
     assert '23' in d.vlan
     assert d.vlan[23]['name'] == 'vingttrois'
     assert '24' not in d.vlan

--- a/tests/test_vlan_ats.py
+++ b/tests/test_vlan_ats.py
@@ -31,61 +31,16 @@ Serial number:
     """]})
 
 
-def test_dashed_vlan(dut, log_level):
-    output_sv_0 = ["""
-
-Vlan       Name                   Ports                Type     Authorization
----- ----------------- --------------------------- ------------ -------------
- 1           1         1/e(1-48),1/g(1-4),          other       Required
-                       2/e(1-48),2/g(1-4),
-                       3/e(1-48),3/g(1-4),
-                       4/e(1-48),4/g(1-4),
-                       5/e(1-48),5/g(1-4),
-                       6/e(1-48),6/g(1-4),ch(1-8)
-    """]
-    output_sr_0 = ["""
-interface vlan 1
-ip address 10.17.39.252 255.255.255.0
-name default_vlan
-exit
-hostname nac_dev
-ip ssh server
-    """]
-
-    output_sv_1 = ["""
-
-Vlan       Name                   Ports                Type     Authorization
----- ----------------- --------------------------- ------------ -------------
- 1           1         1/e(1-48),1/g(1-4),          other       Required
-                       2/e(1-48),2/g(1-4),
-                       3/e(1-48),3/g(1-4),
-                       4/e(1-48),4/g(1-4),
-                       5/e(1-48),5/g(1-4),
-                       6/e(1-48),6/g(1-4),ch(1-8)
- 21          21                                     permanent     Required
- 22          22                                     permanent     Required
- 23          23                                     permanent     Required
- 24          24                                     permanent     Required
- 25          25                                     permanent     Required
-    """]
-    output_sr_1 = ["""
+def test_two_vlans(dut, log_level):
+    output_show_rcfg = ["""
 vlan database
-vlan 21-25
+vlan 21-22
 exit
 interface vlan 21
-name "twentyone"
+name twentyone
 exit
 interface vlan 22
-name "zweiundzwanzig"
-exit
-interface vlan 23
-name "vingttrois"
-exit
-interface vlan 24
-name "ventiquattro"
-exit
-interface vlan 25
-name "vienticinco"
+name zweiundzwanzig
 exit
 interface vlan 1
 ip address 10.17.39.252 255.255.255.0
@@ -93,106 +48,50 @@ name default_vlan
 exit
 hostname nac_dev
 ip ssh server
+    """]
+    output_show_vlan = ["""
+
+Vlan       Name                   Ports                Type     Authorization
+---- ----------------- --------------------------- ------------ -------------
+ 1      default_vlan   1/e(1-48),1/g(1-4),          other       Required
+                       2/e(1-48),2/g(1-4),
+                       3/e(1-48),3/g(1-4),
+                       4/e(1-48),4/g(1-4),
+                       5/e(1-48),5/g(1-4),
+                       6/e(1-48),6/g(1-4),ch(1-8)
+ 21      twentyone                                  permanent     Required
+ 22   zweiundzwanzig                                permanent     Required
     """]
 
     setup_dut(dut)
-    dut.add_cmd({'cmd': 'show vlan'          , 'state':0 , 'action':'PRINT'     ,'args': output_sv_0})
-    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_sr_0})
-    dut.add_cmd({'cmd': 'vlan database'      , 'state':0 , 'action':'SET_PROMPT','args':['(config-vlan)#']})
-    dut.add_cmd({'cmd': 'vlan database'      , 'state':0 , 'action':'SET_STATE' ,'args':[1]})
-    dut.add_cmd({'cmd': 'vlan 21-25'         , 'state':1 , 'action':'SET_STATE' ,'args':[2]})
-    dut.add_cmd({'cmd': 'show vlan'          , 'state':2 , 'action':'PRINT'     ,'args':output_sv_1})
-    dut.add_cmd({'cmd': 'show running-config', 'state':2 , 'action':'PRINT'     ,'args':output_sr_1})
-    dut.add_cmd({'cmd': 'interface vlan 21'  , 'state':2 , 'action':'SET_PROMPT','args':['(config-if)#']})
-    dut.add_cmd({'cmd': 'interface vlan 21'  , 'state':2 , 'action':'SET_STATE' ,'args':[3]})
-    dut.add_cmd({'cmd': 'name twentyone'     , 'state':3 , 'action':'SET_STATE' ,'args':[4]})
-    # dut.add_cmd({'cmd': 'show vlan'          , 'state':4 , 'action':'PRINT'     ,'args':output_sv_1})
-    # dut.add_cmd({'cmd': 'show running-config', 'state':4 , 'action':'PRINT'     ,'args':output_sr_1})
-    dut.add_cmd({'cmd': 'interface vlan 22'  , 'state':4 , 'action':'SET_PROMPT','args':['(config-if)#']})
-    dut.add_cmd({'cmd': 'interface vlan 22'  , 'state':4 , 'action':'SET_STATE' ,'args':[5]})
-    dut.add_cmd({'cmd': 'name zweiundzwanzig', 'state':5 , 'action':'SET_STATE' ,'args':[6]})
-    # dut.add_cmd({'cmd': 'show vlan'          , 'state':6 , 'action':'PRINT'     ,'args':output_sv_1})
-    # dut.add_cmd({'cmd': 'show running-config', 'state':6 , 'action':'PRINT'     ,'args':output_sr_1})
-    dut.add_cmd({'cmd': 'interface vlan 23'  , 'state':6 , 'action':'SET_PROMPT','args':['(config-if)#']})
-    dut.add_cmd({'cmd': 'interface vlan 23'  , 'state':6 , 'action':'SET_STATE' ,'args':[7]})
-    dut.add_cmd({'cmd': 'name vingttrois'    , 'state':7 , 'action':'SET_STATE' ,'args':[8]})
-    # dut.add_cmd({'cmd': 'show vlan'          , 'state':7 , 'action':'PRINT'     ,'args':output_sv_1})
-    # dut.add_cmd({'cmd': 'show running-config', 'state':7 , 'action':'PRINT'     ,'args':output_sr_1})
-    dut.add_cmd({'cmd': 'interface vlan 24'  , 'state':8 , 'action':'SET_PROMPT','args':['(config-if)#']})
-    dut.add_cmd({'cmd': 'interface vlan 24'  , 'state':8 , 'action':'SET_STATE' ,'args':[9]})
-    dut.add_cmd({'cmd': 'name ventiquattro'  , 'state':9 , 'action':'SET_STATE' ,'args':[10]})
-    # dut.add_cmd({'cmd': 'show vlan'          , 'state':10, 'action':'PRINT'     ,'args':output_sv_1})
-    # dut.add_cmd({'cmd': 'show running-config', 'state':10, 'action':'PRINT'     ,'args':output_sr_1})
-    dut.add_cmd({'cmd': 'interface vlan 25'  , 'state':10, 'action':'SET_PROMPT','args':['(config-if)#']})
-    dut.add_cmd({'cmd': 'interface vlan 25'  , 'state':10, 'action':'SET_STATE' ,'args':[11]})
-    dut.add_cmd({'cmd': 'name vienticinco'   , 'state':11, 'action':'SET_STATE' ,'args':[12]})
-    dut.add_cmd({'cmd': 'show vlan'          , 'state':12, 'action':'PRINT'     ,'args':output_sv_1})
-    dut.add_cmd({'cmd': 'show running-config', 'state':12, 'action':'PRINT'     ,'args':output_sr_1})
+    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_show_rcfg})
+    dut.add_cmd({'cmd': 'show vlan'          , 'state':0 , 'action':'PRINT'     ,'args': output_show_vlan})
     d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
     d.open()
-    # d.vlan.create(21)
-    # # d.vlan.create(22)
-    # # d.vlan.create(23)
-    # # d.vlan.create(24)
-    # # d.vlan.create(25)
-    d.vlan.create(21, name='twentyone')
-    d.vlan.create(22, name='zweiundzwanzig')
-    d.vlan.create(23, name='vingttrois')
-    d.vlan.create(24, name='ventiquattro')
-    d.vlan.create(25, name='vienticinco')
-    # d.vlan.update(21, name='twentyone')
-    # d.vlan.update(22, name='zweiundzwanzig')
-    # d.vlan.update(23, name='vingttrois')
-    # d.vlan.update(24, name='ventiquattro')
-    # d.vlan.update(25, name='vienticinco')
     assert '21' in d.vlan
-    assert '22' in d.vlan
-    assert '23' in d.vlan
-    assert '24' in d.vlan
-    assert '25' in d.vlan
+    assert d.vlan[21]['name'] == 'twentyone'
+    assert ('22', {'name': 'zweiundzwanzig', 'tagged': [], 'type': 'permanent', 'untagged': []}) in d.vlan.items()
+    with pytest.raises(TypeError) as excinfo:
+        d.vlan[d.vlan]
     d.close()
 
 
-def test_two_vlans(dut, log_level):
-    output_sv_0 = ["""
-
-Vlan       Name                   Ports                Type     Authorization
----- ----------------- --------------------------- ------------ -------------
- 1           1         1/e(1-48),1/g(1-4),          other       Required
-                       2/e(1-48),2/g(1-4),
-                       3/e(1-48),3/g(1-4),
-                       4/e(1-48),4/g(1-4),
-                       5/e(1-48),5/g(1-4),
-                       6/e(1-48),6/g(1-4),ch(1-8)
-    """]
-    output_sr_0 = ["""
-interface vlan 1
-ip address 10.17.39.252 255.255.255.0
-name default_vlan
-exit
-hostname nac_dev
-ip ssh server
-    """]
-
-    output_sv_1 = ["""
-
-Vlan       Name                   Ports                Type     Authorization
----- ----------------- --------------------------- ------------ -------------
- 1           1         1/e(1-48),1/g(1-4),          other       Required
-                       2/e(1-48),2/g(1-4),
-                       3/e(1-48),3/g(1-4),
-                       4/e(1-48),4/g(1-4),
-                       5/e(1-48),5/g(1-4),
-                       6/e(1-48),6/g(1-4),ch(1-8)
- 21          21                                     permanent     Required
- 22          22                                     permanent     Required
-    """]
-    output_sr_1 = ["""
+def test_vlan_mixed_sequence(dut, log_level):
+    output_show_rcfg = ["""
 vlan database
-vlan 21,22
+vlan 21-23,24
 exit
 interface vlan 21
-name "twentyone"
+name twentyone
+exit
+interface vlan 22
+name zweiundzwanzig
+exit
+interface vlan 23
+name vingttrois
+exit
+interface vlan 24
+name ventiquattro
 exit
 interface vlan 1
 ip address 10.17.39.252 255.255.255.0
@@ -200,35 +99,36 @@ name default_vlan
 exit
 hostname nac_dev
 ip ssh server
+    """]
+    output_show_vlan = ["""
+
+Vlan       Name                   Ports                Type     Authorization
+---- ----------------- --------------------------- ------------ -------------
+ 1      default_vlan   1/e(1-48),1/g(1-4),          other       Required
+                       2/e(1-48),2/g(1-4),
+                       3/e(1-48),3/g(1-4),
+                       4/e(1-48),4/g(1-4),
+                       5/e(1-48),5/g(1-4),
+                       6/e(1-48),6/g(1-4),ch(1-8)
+ 21      twentyone                                  permanent     Required
+ 22   zweiundzwanzig                                permanent     Required
+ 23   vingttrois                                    permanent     Required
+ 24   ventiquattro                                  permanent     Required
     """]
 
     setup_dut(dut)
-    dut.add_cmd({'cmd': 'show vlan'          , 'state':0 , 'action':'PRINT'     ,'args': output_sv_0})
-    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_sr_0})
-    dut.add_cmd({'cmd': 'vlan database'      , 'state':0 , 'action':'SET_PROMPT','args':['(config-vlan)#']})
-    dut.add_cmd({'cmd': 'vlan database'      , 'state':0 , 'action':'SET_STATE' ,'args':[1]})
-    dut.add_cmd({'cmd': 'vlan 21'         , 'state':1 , 'action':'SET_STATE' ,'args':[2]})
-    dut.add_cmd({'cmd': 'show vlan'          , 'state':2 , 'action':'PRINT'     ,'args':output_sv_1})
-    dut.add_cmd({'cmd': 'show running-config', 'state':2 , 'action':'PRINT'     ,'args':output_sr_1})
-    dut.add_cmd({'cmd': 'interface vlan 21'  , 'state':2 , 'action':'SET_PROMPT','args':['(config-if)#']})
-    dut.add_cmd({'cmd': 'interface vlan 21'  , 'state':2 , 'action':'SET_STATE' ,'args':[3]})
-    dut.add_cmd({'cmd': 'name twentyone'     , 'state':3 , 'action':'SET_STATE' ,'args':[4]})
-    dut.add_cmd({'cmd': 'show vlan'          , 'state':4 , 'action':'PRINT'     ,'args':output_sv_1})
-    dut.add_cmd({'cmd': 'show running-config', 'state':4 , 'action':'PRINT'     ,'args':output_sr_1})
-    # dut.add_cmd({'cmd': 'interface vlan 22'  , 'state':4 , 'action':'SET_PROMPT','args':['(config-if)#']})
-    # dut.add_cmd({'cmd': 'interface vlan 22'  , 'state':4 , 'action':'SET_STATE' ,'args':[5]})
-    # dut.add_cmd({'cmd': 'name zweiundzwanzig', 'state':5 , 'action':'SET_STATE' ,'args':[6]})
-    # dut.add_cmd({'cmd': 'show vlan'          , 'state':6 , 'action':'PRINT'     ,'args':output_sv_1})
-    # dut.add_cmd({'cmd': 'show running-config', 'state':6 , 'action':'PRINT'     ,'args':output_sr_1})
+    dut.add_cmd({'cmd': 'show running-config', 'state':0 , 'action':'PRINT'     ,'args': output_show_rcfg})
+    dut.add_cmd({'cmd': 'show vlan'          , 'state':0 , 'action':'PRINT'     ,'args': output_show_vlan})
     d=Device(host=dut.host,port=dut.port,protocol=dut.protocol, log_level=log_level)
     d.open()
-    d.vlan.create(21, name='twentyone')
-    # d.vlan.create(22)
-    # d.vlan.create(22, name='zweiundzwanzig')
-    # d.vlan.update(21, name='twentyone')
-    # d.vlan.update(22, name='zweiundzwanzig')
     assert '21' in d.vlan
-    # assert '22' in d.vlan
+    assert d.vlan[21]['name'] == 'twentyone'
+    assert '22' in d.vlan
+    assert d.vlan[22]['name'] == 'zweiundzwanzig'
+    assert '23' in d.vlan
+    assert d.vlan[23]['name'] == 'vingttrois'
+    assert '24' in d.vlan
+    assert d.vlan[24]['name'] == 'ventiquattro'
     d.close()
 
 


### PR DESCRIPTION
Fixed a bug when parsing a dashed list of VLANs in the configuration (i.e. vlan 21-23).
The bug is present only for ATS devices.
Tested both with AW+ and ATS devices.
